### PR TITLE
Public Url From Fog

### DIFF
--- a/lib/s3_uploader/s3_uploader.rb
+++ b/lib/s3_uploader/s3_uploader.rb
@@ -57,13 +57,18 @@ module S3Uploader
           file = files.pop
           key = file.gsub(source, '')[1..-1]
           dest = "#{options[:destination_dir]}#{key}"
-          log.info("[#{file_number}/#{total_files}] Uploading #{key} to s3://#{bucket}/#{dest}")
           
-          directory.files.create(
+          uploaded_file = directory.files.create(
             :key    => dest,
             :body   => File.open(file),
             :public => options[:public]
           )
+
+          if options[:public]
+            puts "[#{file_number}/#{total_files}] Uploading #{key} to " + uploaded_file.public_url
+          else
+            log.info("[#{file_number}/#{total_files}] Uploading #{key} to s3://#{bucket}/#{dest}")
+          end
         end 
       }
     end


### PR DESCRIPTION
Change the output for public and private files, found it beneficial to have the public url.

I needed this for my specific use case. Not sure if it benefits anyone else at all, but if I was making the files public it was easier to just have the public URL given back from Fog.
