### PR TITLE
Add metadata to control headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,18 +32,19 @@ Or install it yourself as:
 			:s3_secret => YOUR_SECRET_KEY,
 			:destination_dir => 'test/',
 			:region => 'eu-west-1',
-			:threads => 4 })
+			:threads => 4
+      :metadata => {'Cache-Control' => 'max-age=315576000'} })
 
 If no keys are provided, it uses S3_KEY and S3_SECRET environment variables. us-east-1 is the default region.
 
 	S3Uploader.upload_directory('/tmp/test', 'mybucket', { :destination_dir => 'test/', :threads => 4 })
-	
+
 Or as a command line binary
-	
+
 	s3uploader -r eu-west-1 -k YOUR_KEY -s YOUR_SECRET_KEY -d test/ -t 4 /tmp/test mybucket
-	
+
 Again, it uses S3_KEY and S3_SECRET environment variables if non provided in parameters.
-	
+
 	s3uploader -d test/ -t 4 /tmp/test mybucket
 
 ## TODO

--- a/lib/s3_uploader/s3_uploader.rb
+++ b/lib/s3_uploader/s3_uploader.rb
@@ -7,7 +7,8 @@ module S3Uploader
       :s3_key => ENV['S3_KEY'],
       :s3_secret => ENV['S3_SECRET'],
       :public => false,
-      :region => 'us-east-1'
+      :region => 'us-east-1',
+      :metadata => {}
     }.merge(options)
 
     log = options[:logger] || Logger.new(STDOUT)
@@ -65,7 +66,7 @@ module S3Uploader
               :key    => dest,
               :body   => File.open(file),
               :public => options[:public],
-              :metadata => { "Cache-Control" => "max-age=#{60 * 60 * 24 * 30 * 12}" }
+              :metadata => options[:metadata]
             )
           end
         end


### PR DESCRIPTION
I'm using the gem to upload out public assets to S3 and it works great. Thanks!

However, I need to set some headers on them and it appears you can do this via Fog with the metadata options (http://stackoverflow.com/questions/10474905/how-do-i-set-cache-control-header-for-cloud-files-with-fog).
