### PR TITLE
bugfix: 'binread': failed to allocate memory (NoMemoryError), now using ...

### DIFF
--- a/lib/s3_uploader/s3_uploader.rb
+++ b/lib/s3_uploader/s3_uploader.rb
@@ -53,11 +53,7 @@ module S3Uploader
           gz_file   = "#{dir}/#{base}.gz"
 
           FileUtils.mkdir_p(dir) unless File.directory?(dir)
-          Zlib::GzipWriter.open(gz_file) do |gz|
-            gz.mtime     = File.mtime(f)
-            gz.orig_name = f
-            gz.write IO.binread(f)
-          end
+          system("gzip -c #{f} > #{gz_file}")
           files << gz_file
           total_size += File.size(gz_file)
         else


### PR DESCRIPTION
...gzip-system-call

Zlib::GzipWriter failed to allocate memory when trying to gzip a file with size > memory.

tests are still green