### PR TITLE
Close opened files

### DIFF
--- a/lib/s3_uploader/s3_uploader.rb
+++ b/lib/s3_uploader/s3_uploader.rb
@@ -110,14 +110,16 @@ module S3Uploader
           if file
             key = file.gsub(source, '').gsub(options[:gzip_working_dir].to_s, '')[1..-1]
             dest = "#{options[:destination_dir]}#{key}"
+            body = File.open(file)
             log.info("[#{Thread.current["file_number"]}/#{total_files}] Uploading #{key} to s3://#{bucket}/#{dest}")
 
             directory.files.create(
               :key    => dest,
-              :body   => File.open(file),
+              :body   => body,
               :public => options[:public],
               :metadata => options[:metadata]
             )
+            body.close
           end
         end
       end


### PR DESCRIPTION
Hello Christian,

Fog is not closing files after uploading so we need to do it at this level. In regular cases this is not an issue but if we use this method to upload a directory with a big number of files it can reach the limit of file descriptors in the machine.

Thanks!