### PR TITLE
don't mangle filenames prior to upload

### DIFF
--- a/lib/s3_uploader/s3_uploader.rb
+++ b/lib/s3_uploader/s3_uploader.rb
@@ -108,7 +108,7 @@ module S3Uploader
           end
           file = files.pop rescue nil
           if file
-            key = file.gsub(source, '').gsub(options[:gzip_working_dir].to_s, '')[1..-1]
+            key = file.sub(source, '').sub(options[:gzip_working_dir].to_s, '')[1..-1]
             dest = "#{options[:destination_dir]}#{key}"
             body = File.open(file)
             log.info("[#{Thread.current["file_number"]}/#{total_files}] Uploading #{key} to s3://#{bucket}/#{dest}")


### PR DESCRIPTION
gsub replaces all instances of a substring within a string.  As a
result destination filenames were being uploaded with part of the
filename removed.

To reproduce create the following file
/test/subdir/this-file-is-a-test.txt
then call s3uploader with the directory test
S3Uploader.upload_directory(‘test’, etc….